### PR TITLE
fixes-update-percentage-#4

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,6 +2,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+mod percentage_update;
 mod activity_log_retrieval;
 mod health_check;
 mod subscription;
@@ -22,4 +23,5 @@ pub fn router() -> Router<AppState> {
         .route("/unsubscribe", post(unsubscription::handle_unsubscribe))
         .route("/subscriptions", post(subscription::create_subscription))
         .route("/log_retrieval", get(activity_log_retrieval::log_retrieval))
+        .route("/update-percentage", post(percentage_update::update_percentage))
 }

--- a/src/http/percentage_update.rs
+++ b/src/http/percentage_update.rs
@@ -1,0 +1,36 @@
+use axum::{extract::State, http::StatusCode, Json};
+use super::types::{UpdatePercentageRequest, UpdatePercentageResponse};
+use crate::AppState;
+
+pub async fn update_percentage(
+    State(state): State<AppState>,
+    Json(payload): Json<UpdatePercentageRequest>,
+) -> Result<Json<UpdatePercentageResponse>, StatusCode> {
+    // wallet address validation
+    if !payload.wallet_address.starts_with("0x") && payload.wallet_address.len() != 42 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // percent updte
+    let result = sqlx::query!(
+        r#"
+        UPDATE swap_subscription_from_token 
+        SET percentage = $1, updated_at = NOW()
+        WHERE wallet_address = $2 AND from_token = $3
+        "#,
+        payload.percentage,
+        payload.wallet_address,
+        payload.from_token
+    )
+    .execute(&state.db.pool)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if result.rows_affected() == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(Json(UpdatePercentageResponse {
+        message: "Percentage updated successfully".to_string(),
+    }))
+}

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -80,3 +80,15 @@ impl<'de> Deserialize<'de> for TimeStamptz {
         deserializer.deserialize_str(StrVisitor)
     }
 }
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatePercentageRequest {
+    pub wallet_address: String,
+    pub from_token: String,  
+    pub percentage: i16
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdatePercentageResponse {
+    pub message: String,
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -4,3 +4,4 @@ mod helpers;
 mod subscription;
 mod transaction_logs;
 mod unsubscription;
+mod percentage_update;

--- a/tests/api/percentage_update.rs
+++ b/tests/api/percentage_update.rs
@@ -1,0 +1,105 @@
+use axum::{
+    body::Body,
+    http::{header::CONTENT_TYPE, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+
+use crate::helpers::*;
+
+async fn setup_test_data(pool: &PgPool, wallet_address: &str, from_token: &str, initial_percentage: i16) {
+    sqlx::query!(
+        r#"
+        INSERT INTO swap_subscription (wallet_address, to_token, is_active)
+        VALUES ($1, $2, true)
+        ON CONFLICT (wallet_address)
+        DO UPDATE SET to_token = $2, is_active = true, updated_at = NOW()
+        "#,
+        wallet_address,
+        "0x1234567890123456789012345678901234567890"
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query!(
+        r#"
+            INSERT INTO swap_subscription_from_token
+            (wallet_address, from_token, percentage)
+            VALUES ($1, $2, $3)
+            "#,
+        wallet_address,
+        from_token,
+        initial_percentage,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_update_percentage_success() {
+    let app = TestApp::new().await;
+    
+    clean_database(&app.db.pool).await;
+    
+    let wallet_address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+    let from_token = "0xabcdef0123456789abcdef0123456789abcdef01";
+    let initial_percentage = 50;
+    
+    setup_test_data(&app.db.pool, wallet_address, from_token, initial_percentage).await;
+    
+    let payload = json!({
+        "wallet_address": wallet_address,
+        "from_token": from_token,
+        "percentage": 75
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/update-percentage")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&payload).unwrap()))
+        .unwrap();
+
+    let resp = app.request(req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let updated = sqlx::query!(
+        r#"
+        SELECT percentage 
+        FROM swap_subscription_from_token
+        WHERE wallet_address = $1 AND from_token = $2
+        "#,
+        wallet_address,
+        from_token
+    )
+    .fetch_one(&app.db.pool)
+    .await
+    .unwrap();
+
+    assert_eq!(updated.percentage, 75);
+}
+
+#[tokio::test]
+async fn test_update_percentage_not_found() {
+    let app = TestApp::new().await;
+    
+    clean_database(&app.db.pool).await;
+    
+    let payload = json!({
+        "wallet_address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+        "from_token": "0xabcdef0123456789abcdef0123456789abcdef01",
+        "percentage": 75
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/update-percentage")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&payload).unwrap()))
+        .unwrap();
+
+    let resp = app.request(req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/tests/api/subscription.rs
+++ b/tests/api/subscription.rs
@@ -7,29 +7,6 @@ use sqlx::PgPool;
 
 use crate::helpers::*;
 
-async fn clean_database(pool: &PgPool) {
-    let _ = sqlx::query!("SELECT COUNT(*) FROM swap_subscription")
-        .fetch_one(pool)
-        .await
-        .unwrap_or_else(|_| panic!("Database tables not ready"));
-
-    sqlx::query!("DELETE FROM swap_subscription_from_token")
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query!("DELETE FROM swap_subscription")
-        .execute(pool)
-        .await
-        .unwrap();
-
-    let count = sqlx::query!("SELECT COUNT(*) as count FROM swap_subscription")
-        .fetch_one(pool)
-        .await
-        .unwrap();
-
-    println!("Database cleaned. Subscription count: {:?}", count.count);
-}
-
 #[tokio::test]
 async fn test_subscribe_ok() {
     let app = TestApp::new().await;


### PR DESCRIPTION

## Introduces Update Percentage Service #4

fixes #4 

1. Added new request/response types in src/http/types.rs:

```rust
UpdatePercentageRequest {wallet_address, from_token, percentage} and UpdatePercentageResponse {message}
```
2. Created src/http/percentage_update.rs with handler:
```rust
async fn update_percentage()
```
implementing validation and DB update logic

3. Added module and route in src/http/mod.rs:

```rust
mod percentage_update and .route("/update-percentage", post(percentage_update::update_percentage))
```

4. Created tests/api/percentage_update.rs with tests:
```rust
test_update_percentage_success and test_update_percentage_not_found tests
```


The given implementation makes sure it passes all test cases.

## Output
- Receives input containing wallet address, token address, and new percentage value
- Returns a success message when percentage is updated:

![image](https://github.com/user-attachments/assets/3936d517-48fc-4dd0-8af1-615e29075153)

