### PR TITLE
refactor: implement wallet address validation function

### DIFF
--- a/src/http/percentage_update.rs
+++ b/src/http/percentage_update.rs
@@ -1,4 +1,4 @@
-use super::types::{SuccessResponse, UpdatePercentageRequest};
+use super::types::{is_valid_address, SuccessResponse, UpdatePercentageRequest};
 use crate::AppState;
 use axum::{extract::State, http::StatusCode, Json};
 
@@ -13,7 +13,7 @@ pub async fn update_percentage(
     } = payload;
 
     // wallet address validation
-    if !wallet_address.starts_with("0x") || wallet_address.len() != 66 {
+    if !is_valid_address(&wallet_address) {
         return Err(StatusCode::BAD_REQUEST);
     }
     if percentage <= 0 || percentage > 100 {

--- a/src/http/subscription.rs
+++ b/src/http/subscription.rs
@@ -1,8 +1,8 @@
 use axum::{extract::Query, extract::State, http::StatusCode, Json};
 
 use super::types::{
-    CreateSubscriptionRequest, GetSubscriptionRequest, GetSubscriptionResponse, SubscriptionData,
-    SuccessResponse,
+    is_valid_address, CreateSubscriptionRequest, GetSubscriptionRequest, GetSubscriptionResponse,
+    SubscriptionData, SuccessResponse,
 };
 use crate::api_error::ApiError;
 use crate::AppState;
@@ -28,11 +28,7 @@ pub async fn create_subscription(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    if !to_token.starts_with("0x") || to_token.len() != 66 {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    if !wallet_address.starts_with("0x") || wallet_address.len() != 66 {
+    if !is_valid_address(&to_token) || !is_valid_address(&wallet_address) {
         return Err(StatusCode::BAD_REQUEST);
     }
 

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -5,6 +5,9 @@ use std::fmt::Formatter;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+pub const ADDRESS_PREFIX: &str = "0x";
+pub const ADDRESS_LENGTH: usize = 66;
+
 #[derive(Debug, Deserialize)]
 pub struct ActivityLogGetRequest {
     pub wallet_address: Option<String>,
@@ -127,4 +130,43 @@ pub struct UpdatePercentageRequest {
 #[derive(Debug, Serialize)]
 pub struct UpdatePercentageResponse {
     pub message: String,
+}
+
+/// Returns true if the wallet address is valid.
+pub fn is_valid_address(address: &str) -> bool {
+    address.starts_with(ADDRESS_PREFIX)
+        && address.len() == ADDRESS_LENGTH
+        && address[2..].chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_address() {
+        assert!(is_valid_address(
+            "0x40ca979f20ed76f960dc719457eaf0cef3b2c3932d58435b9192a58bc56c1e40"
+        ));
+    }
+
+    #[test]
+    fn test_invalid_addresses() {
+        let long_zeros = "0".repeat(64);
+        let long_as = "a".repeat(67);
+
+        let invalid_addresses = vec![
+            "",
+            "0x",
+            "0x123",
+            "123456",
+            "0xXYZabc",
+            &long_zeros,
+            &long_as,
+        ];
+
+        for addr in invalid_addresses {
+            assert!(!is_valid_address(addr));
+        }
+    }
 }

--- a/src/http/unsubscription.rs
+++ b/src/http/unsubscription.rs
@@ -1,7 +1,7 @@
 use axum::{extract::State, Json};
 use serde::Deserialize;
 
-use super::types::SuccessResponse;
+use super::types::{is_valid_address, SuccessResponse};
 use crate::{api_error::ApiError, AppState};
 
 #[derive(Debug, Deserialize)]
@@ -20,14 +20,14 @@ pub async fn handle_unsubscribe(
     } = payload;
 
     // Validate wallet_address format
-    if !wallet_address.starts_with("0x") || wallet_address.len() != 66 {
+    if !is_valid_address(&wallet_address) {
         return Err(ApiError::InvalidRequest(
             "Invalid wallet address format".to_string(),
         ));
     }
 
     // Validate from_token format
-    if !from_token.starts_with("0x") || from_token.len() != 66 {
+    if !is_valid_address(&from_token) {
         return Err(ApiError::InvalidRequest(
             "Invalid token address format".to_string(),
         ));


### PR DESCRIPTION
The `validate_address` method in [`src/service/transaction_logs.rs`](https://github.com/BlockheaderWeb3-Community/autoswappr-backend/blob/f906a2e24e959025f5b342319106e713b42a9344/src/service/transaction_logs.rs#L44) meets the issue conditions. I left it unchanged to avoid making `types.rs` public or moving shared logic into a separate module. Let me know if you think this change is necessary.

### Refactoring and Utility Function Addition:

* [`src/http/types.rs`](diffhunk://#diff-41c7675b4c0e2d99a505042091d3bc53ca637b9627131d756f39b94281da69b9R8-R10): Added `is_valid_address` function for wallet address validation, along with constants `ADDRESS_PREFIX` and `ADDRESS_LENGTH`, and unit tests. [[1]](diffhunk://#diff-41c7675b4c0e2d99a505042091d3bc53ca637b9627131d756f39b94281da69b9R8-R10) [[2]](diffhunk://#diff-41c7675b4c0e2d99a505042091d3bc53ca637b9627131d756f39b94281da69b9R134-R172)

### Refactoring to Use Utility Function:

* [`src/http/percentage_update.rs`](diffhunk://#diff-0e3bc972977188d73ad382fb17212cb24cd116deb9db1983107379ee41b1a6f3L1-R1): Refactored `update_percentage` to use `is_valid_address` for wallet address validation. [[1]](diffhunk://#diff-0e3bc972977188d73ad382fb17212cb24cd116deb9db1983107379ee41b1a6f3L1-R1) [[2]](diffhunk://#diff-0e3bc972977188d73ad382fb17212cb24cd116deb9db1983107379ee41b1a6f3L16-R16)
* [`src/http/subscription.rs`](diffhunk://#diff-d6c60aca1f7b8767f93f83a419ff0bd85296f6a47f94be9d4549a7694a040a01L4-R5): Refactored `create_subscription` to validate `to_token` and `wallet_address` using `is_valid_address`. [[1]](diffhunk://#diff-d6c60aca1f7b8767f93f83a419ff0bd85296f6a47f94be9d4549a7694a040a01L4-R5) [[2]](diffhunk://#diff-d6c60aca1f7b8767f93f83a419ff0bd85296f6a47f94be9d4549a7694a040a01L31-R31)
* [`src/http/unsubscription.rs`](diffhunk://#diff-74895a1c5dc267f9b01c45cf31ade13dca1783556b451621172ba1479fb81467L4-R4): Updated `handle_unsubscribe` to use `is_valid_address` for `wallet_address` and `from_token` validation. [[1]](diffhunk://#diff-74895a1c5dc267f9b01c45cf31ade13dca1783556b451621172ba1479fb81467L4-R4) [[2]](diffhunk://#diff-74895a1c5dc267f9b01c45cf31ade13dca1783556b451621172ba1479fb81467L23-R30)

Closes #26 